### PR TITLE
Refactor: Adjust UI elements for better spacing and sizing

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/free/youtube/ui/DownloadOptionsHeader.kt
+++ b/composeApp/src/commonMain/kotlin/org/free/youtube/ui/DownloadOptionsHeader.kt
@@ -73,6 +73,7 @@ fun DownloadOptionsHeader(modifier: Modifier = Modifier) {
                     style = MaterialTheme.typography.titleSmall,
                     color = YouTubeDownloaderTheme.TextSecondary,
                     fontSize = 14.sp,
+                    modifier = modifier.padding(bottom = 4.dp)
                 )
                 val resolutions = listOf("2160p", "1080p", "720p", "480p")
 
@@ -83,18 +84,17 @@ fun DownloadOptionsHeader(modifier: Modifier = Modifier) {
                 )
             }
 
-
             Column(
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
                     .padding(start = 8.dp)
-                    .fillMaxWidth(0.25f)
             ) {
                 Text(
                     text = "Audio",
                     style = MaterialTheme.typography.titleSmall,
                     color = YouTubeDownloaderTheme.TextSecondary,
                     fontSize = 14.sp,
+                    modifier = Modifier.padding(bottom = 4.dp)
                 )
                 Button(
                     onClick = {
@@ -103,7 +103,9 @@ fun DownloadOptionsHeader(modifier: Modifier = Modifier) {
                             else -> YouTubeDownloaderTheme.ButtonDeactivated
                         }
                     },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .width(48.dp)
+                        .height(48.dp),
                     shape = YouTubeDownloaderTheme.Shapes.medium,
                     colors = ButtonDefaults.buttonColors(
                         containerColor = animatedBackgroundColor,
@@ -112,13 +114,14 @@ fun DownloadOptionsHeader(modifier: Modifier = Modifier) {
                     border = BorderStroke(
                         width = 1.dp,
                         color = YouTubeDownloaderTheme.BorderDefault
-                    )
+                    ),
+                    contentPadding = PaddingValues(0.dp)
                 ) {
                     Icon(
                         painter = painterResource(Res.drawable.audio),
                         contentDescription = "Audio Icon",
-                        modifier = Modifier.size(16.dp),
-                        tint = YouTubeDownloaderTheme.TextPrimary
+                        modifier = Modifier.size(20.dp), // Icon size
+                        tint = animatedContentColor
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/free/youtube/ui/ResolutionSelector.kt
+++ b/composeApp/src/commonMain/kotlin/org/free/youtube/ui/ResolutionSelector.kt
@@ -60,9 +60,8 @@ fun ResolutionSelector(
                 disabledContainerColor = YouTubeDownloaderTheme.BackgroundTertiary,
                 disabledContentColor = YouTubeDownloaderTheme.TextMuted
             ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp), // Better touch target height
+            modifier = modifier
+                .height(48.dp),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp) // Better internal padding
         ) {
             Row(

--- a/composeApp/src/commonMain/kotlin/org/free/youtube/ui/VideoPrevisualizer.kt
+++ b/composeApp/src/commonMain/kotlin/org/free/youtube/ui/VideoPrevisualizer.kt
@@ -46,7 +46,7 @@ import org.free.youtube.utils.isYouTubeUrl
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
-fun VideoPrevisualizer(modifier: Modifier) { // Its a preview
+fun VideoPrevisualizer(modifier: Modifier) {
     var ytURL by remember { mutableStateOf("") }
     val customEnterTransition = scaleIn(initialScale = 0.8f) +
             expandHorizontally(expandFrom = Alignment.End) +


### PR DESCRIPTION
- **DownloadOptionsHeader.kt:**
    - Added bottom padding to "Quality" and "Audio" labels.
    - Set fixed width and height for the "Audio" button.
    - Adjusted content padding for the "Audio" button.
    - Changed "Audio" button icon size.
- **ResolutionSelector.kt:**
    - Removed `fillMaxWidth()` from the resolution selector button to allow it to size based on content.
- **VideoPrevisualizer.kt:**
    - Removed a comment.