### PR TITLE
Refactor: Introduce expect/actual for YtVideo and add logging

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
+        alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
@@ -32,6 +32,11 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
+
+            // test
+
+            implementation(libs.kotlin.test)
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0") // Or the latest version
             
             // Ktor client dependency required for Coil
             implementation(libs.ktor.client.android)
@@ -54,6 +59,8 @@ kotlin {
             implementation(compose.components.resources)
             implementation(libs.coil.compose)
             implementation(libs.coil.network.ktor)
+            // commonMain timber
+            implementation("co.touchlab:kermit:2.0.4")  // or latest version
 
         }
         iosMain.dependencies {
@@ -61,7 +68,7 @@ kotlin {
             implementation(libs.ktor.client.darwin)
         }
         commonTest.dependencies {
-            implementation(libs.kotlin.test)
+
         }
 
         // alternatively jvmMain (maybe later)
@@ -70,6 +77,9 @@ kotlin {
 //            implementation(libs.ktor.client.java)
 //            implementation(libs.kotlinx.coroutines.swing)
 //        }
+    }
+    sourceSets.androidMain.dependencies {
+        implementation(kotlin("test"))
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/org/free/youtube/domain/MyAppTest.kt
+++ b/composeApp/src/androidMain/kotlin/org/free/youtube/domain/MyAppTest.kt
@@ -1,0 +1,20 @@
+package org.free.youtube.domain
+
+import org.junit.jupiter.api.Assertions.*
+
+class MyAppTest {
+    private val ytVideo: YtVideo = provideYtVideo()
+
+    @Test
+    fun testGetVideoInfoReturnsValidData() = runTest {
+        val testUrl = "https://www.youtube.com/watch?v=YSyIa4jI66c" // a known valid test URL
+
+        val videoInfo: CommonVideoInfo? = ytVideo.getVideoInfo(testUrl)
+
+        assertNotNull(videoInfo, "Expected non-null videoInfo")
+        assertTrue(!videoInfo.title.isNullOrEmpty(), "Expected non-empty title")
+
+        println("Video title: ${videoInfo.title}")
+        println("Video duration: ${videoInfo.duration}")
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/free/youtube/domain/VideoDownloader.kt
+++ b/composeApp/src/androidMain/kotlin/org/free/youtube/domain/VideoDownloader.kt
@@ -74,3 +74,5 @@ class YtVideoImpl : YtVideo {
     }
 }
 
+actual fun provideYtVideo(): YtVideo = YtVideoImpl()
+

--- a/composeApp/src/commonMain/kotlin/org/free/youtube/domain/VideoDownloader.kt
+++ b/composeApp/src/commonMain/kotlin/org/free/youtube/domain/VideoDownloader.kt
@@ -3,3 +3,5 @@ package org.free.youtube.domain
 expect interface YtVideo {
     suspend fun getVideoInfo(url: String): CommonVideoInfo?
 }
+
+expect fun provideYtVideo(): YtVideo


### PR DESCRIPTION
This commit refactors the `YtVideo` interface to use `expect` and `actual` declarations for platform-specific implementations.

Key changes:
- Added `expect fun provideYtVideo(): YtVideo` in `commonMain`.
- Provided an `actual` implementation for `provideYtVideo` in `androidMain`.
- Integrated Kermit logger in `VideoPrevisualizer.kt` to log URL changes and video info fetching.
- Added a `LaunchedEffect` in `VideoPrevisualizer.kt` to fetch video information when the URL changes.
- Display video title and duration or error messages based on the fetched video information.
- Added test dependencies (`kotlin-test`, `kotlinx-coroutines-test`) to `composeApp/build.gradle.kts`.
- Created a new test class `MyAppTest.kt` in `androidMain` to test `getVideoInfo`. (INCOMPLETE)